### PR TITLE
Update Rabbithole grants - Arbitrum STIP - in evm_grants.csv

### DIFF
--- a/uploads/evm_grants.csv
+++ b/uploads/evm_grants.csv
@@ -5,7 +5,7 @@ Arbitrum Foundation,Stargate Finance,1/1/2024,0x912ce59144191c1204e64559fe8253a0
 Arbitrum Foundation,Wormhole,1/1/2024,0x912ce59144191c1204e64559fe8253a0e49e6548,1800000,STIP,1,proactive,growth,claim,arbitrum,wormhole,,
 Arbitrum Foundation,Magpie,1/1/2024,0x912ce59144191c1204e64559fe8253a0e49e6548,1250000,STIP,1,proactive,growth,claim,arbitrum,"magpie,magpie_beta",,
 Arbitrum Foundation,WOOFi,1/1/2024,0x912ce59144191c1204e64559fe8253a0e49e6548,1000000,STIP,1,proactive,growth,claim,arbitrum,"woofi,woofi_earn,woofi_staking_v2,woofi_swap",,
-Arbitrum Foundation,RabbitHole,1/1/2024,0x912ce59144191c1204e64559fe8253a0e49e6548,1000000,STIP,1,proactive,growth,claim,arbitrum,rabbithole,https://dune.com/rabbithole/stip,
+Arbitrum Foundation,RabbitHole,1/1/2024,0x912ce59144191c1204e64559fe8253a0e49e6548,1000000,STIP,1,proactive,growth,claim,arbitrum,"boost,boost_arbitrum",https://dune.com/boost_xyz/stip,https://forum.arbitrum.foundation/t/rabbithole-final-stip-round-1/17159
 Arbitrum Foundation,dForce,1/1/2024,0x912ce59144191c1204e64559fe8253a0e49e6548,1000000,STIP,1,proactive,growth,claim,arbitrum,dforcearb,,
 Arbitrum Foundation,Vela,1/1/2024,0x912ce59144191c1204e64559fe8253a0e49e6548,1000000,STIP,1,proactive,growth,claim,arbitrum,"vela,vela_exchange",,
 Arbitrum Foundation,Shell Protocol,1/1/2024,0x912ce59144191c1204e64559fe8253a0e49e6548,750000,STIP,1,proactive,growth,claim,arbitrum,shellprotocol,,


### PR DESCRIPTION
**Is this linked to an existing issue**
If so, link that issue(s) here.

**Fill out the following table describing your edits:**

| Original | Updated | Change | Reasoning |
|---|---|---|---|
| [3237745](https://dune.com/queries/3237745) | [3237938](https://dune.com/queries/3238935) | Remove sandwich traders using dex.sandwiches | We should only care about traders who are not doing MEV |
| `evm_grants.csv` | n/a | added grants for Optimism | captures approved grants only |

**Provide any other context or screenshots that explain or justify the changes above:**

---

**Note to Contributor:**

Make sure your PR edits the original `query_id.sql` file with the new query text. If you are proposing adding a new query completely, make sure to add it to `queries.yml` and as a file in `/queries` as well.

Thanks for contributing! 🙏

